### PR TITLE
Disabled scalability test and include ranking in build

### DIFF
--- a/releng/dev.arcovia.mitigation.targetplatform/dev.arcovia.mitigation.targetplatform.targetplatform.target
+++ b/releng/dev.arcovia.mitigation.targetplatform/dev.arcovia.mitigation.targetplatform.targetplatform.target
@@ -138,7 +138,7 @@
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
 <unit id="org.dataflowanalysis.analysis.feature.feature.group" version="0.0.0"/>
 <unit id="org.dataflowanalysis.converter.feature.feature.group" version="0.0.0"/>
-      <unit id="org.dataflowanalysis.examplemodels.feature.feature.group" version="0.0.0"/>
+<unit id="org.dataflowanalysis.examplemodels.feature.feature.group" version="0.0.0"/>
 <unit id="org.dataflowanalysis.dfd.dataflowdiagram.feature.feature.group" version="0.0.0"/>
 <unit id="org.dataflowanalysis.dfd.datadictionary.feature.feature.group" version="0.0.0"/>
 

--- a/tests/dev.arcovia.mitigation.ranking.tests/src/dev/arcovia/mitigation/ranking/tests/ScalabilityBase.java
+++ b/tests/dev.arcovia.mitigation.ranking.tests/src/dev/arcovia/mitigation/ranking/tests/ScalabilityBase.java
@@ -1,5 +1,6 @@
 package dev.arcovia.mitigation.ranking.tests;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import dev.arcovia.mitigation.ranking.MitigationStrategy;
@@ -36,31 +37,37 @@ public abstract class ScalabilityBase extends MitigationTestBase {
     }
 
     @Test
+    @Disabled
     public void executeHalf() {
         executeMitigationStrategy(MitigationStrategy.HALF);
     }
 
     @Test
+    @Disabled
     public void executeQuarter() {
         executeMitigationStrategy(MitigationStrategy.QUATER);
     }
 
     @Test
+    @Disabled
     public void executeIncreasing() {
         executeMitigationStrategy(MitigationStrategy.INCREASING);
     }
 
     @Test
+    @Disabled
     public void executeCluster() {
         executeMitigationStrategy(MitigationStrategy.CLUSTER);
     }
 
     @Test
+    @Disabled
     public void executeFastStart() {
         executeMitigationStrategy(MitigationStrategy.FAST_START);
     }
 
     @Test
+    @Disabled
     public void executeBruteForce() {
         executeMitigationStrategy(MitigationStrategy.BRUTE_FORCE);
     }

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -13,6 +13,7 @@
 	<packaging>pom</packaging>
 
 	<modules>
+		<module>dev.arcovia.mitigation.ranking.tests</module>
 		<module>dev.arcovia.mitigation.sat.tests</module>
 	</modules>
 	


### PR DESCRIPTION
This PR disables the scalabilty eval to include the ranking tests in the build pipeline